### PR TITLE
Remove omitempty from AnchorIgnoreIfNotPresent

### DIFF
--- a/v2.1/model/model.go
+++ b/v2.1/model/model.go
@@ -143,7 +143,7 @@ type TabPosition struct {
 	// Reserved for DocuSign.
 	AnchorHorizontalAlignmentMetadata *PropertyMetadata `json:"anchorHorizontalAlignmentMetadata,omitempty"`
 	// When set to **true**, this tab is ignored if the `anchorString` is not found in the document.
-	AnchorIgnoreIfNotPresent DSBool `json:"anchorIgnoreIfNotPresent,omitempty"`
+	AnchorIgnoreIfNotPresent DSBool `json:"anchorIgnoreIfNotPresent"`
 	// Metadata that indicates whether the `anchorIgnoreIfNotPresent` property is editable.
 	AnchorIgnoreIfNotPresentMetadata *PropertyMetadata `json:"anchorIgnoreIfNotPresentMetadata,omitempty"`
 	// Reserved for DocuSign.


### PR DESCRIPTION
Hello @jfcote87, thanks for this package.

I was trying to use anchor tags to position a signing tab, but I had a problem with "AnchorIgnoreIfNotPresent". I needed to use it as "false", but the json tag has "omitempy", which resulted in this property being removed from the payload. Then when the document is sent without the Anchor String it doesn't trigger an error (which is what this property is used for) and creates an envelope without any signing tab.

Removing the omitempty property fixes this issue.